### PR TITLE
Fix get in InlineTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.0.1 - 2024-07-14
+
+- Fixed a bug where `get` would not work in `InlineTable`.
 
 ## v1.0.0 - 2024-05-04
 

--- a/src/tom.gleam
+++ b/src/tom.gleam
@@ -126,6 +126,7 @@ pub fn get(
     [k, ..key] -> {
       case dict.get(toml, k) {
         Ok(Table(t)) -> push_key(get(t, key), k)
+        Ok(InlineTable(t)) -> push_key(get(t, key), k)
         Ok(other) -> Error(WrongType([k], "Table", classify(other)))
         Error(_) -> Error(NotFound([k]))
       }

--- a/test/tom_test.gleam
+++ b/test/tom_test.gleam
@@ -1,4 +1,7 @@
 import gleam/dict
+import gleam/io
+import gleam/result
+import gleam/string
 import gleeunit
 import gleeunit/should
 import tom
@@ -422,10 +425,10 @@ pub fn parse_array_of_tables_nonempty_test() {
     ])
   "[[a]]
 a = 1
-  
+
 [[a]]
 a = 2
-  
+
 [[a]]
 a = 3
 "
@@ -927,4 +930,30 @@ pub fn parse_not_remove_hash_in_string_test() {
 field = \"#\""
   |> tom.parse
   |> should.equal(Ok(expected))
+}
+
+pub fn get_data_in_table_and_inline_table_test() {
+  let toml =
+    "section = { field = \"data\" }
+another_section = { another_field = \"another_data\", int_field = 2 }
+[still_a_section]
+still_a_field = 1"
+    |> tom.parse
+    |> io.debug
+  toml
+  |> result.is_ok
+  |> should.equal(True)
+  use toml <- result.map(toml)
+
+  tom.get(toml, ["section", "field"])
+  |> should.equal(Ok(tom.String("data")))
+
+  tom.get(toml, ["another_section", "another_field"])
+  |> should.equal(Ok(tom.String("another_data")))
+
+  tom.get(toml, ["another_section", "int_field"])
+  |> should.equal(Ok(tom.Int(2)))
+
+  tom.get(toml, ["still_a_section", "still_a_field"])
+  |> should.equal(Ok(tom.Int(1)))
 }


### PR DESCRIPTION
Hi!

Inline Tables should behave in the same way as Table for getting keys. 🙂
This creates a bug right now, where to Toml files that are semantically identical, are treated differently.

Have a nice day!