### PR TITLE
cast inline table as a table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- Fixed bug where `InlineTable` could not be cast `as_table`.
+
 ## v1.1.0 - 2024-09-23
 
 - Added the `as_array`, `as_bool`, `as_date`, `as_date_time`, `as_float`,

--- a/src/tom.gleam
+++ b/src/tom.gleam
@@ -1505,6 +1505,7 @@ pub fn as_array(toml: Toml) -> Result(List(Toml), GetError) {
 pub fn as_table(toml: Toml) -> Result(Dict(String, Toml), GetError) {
   case toml {
     Table(tbl) -> Ok(tbl)
+    InlineTable(tbl) -> Ok(tbl)
     other -> Error(WrongType([], "Table", classify(other)))
   }
 }

--- a/test/tom_test.gleam
+++ b/test/tom_test.gleam
@@ -1038,6 +1038,9 @@ pub fn tom_as_table_test() {
   tom.as_table(tom.Table(dict))
   |> should.equal(Ok(dict))
 
+  tom.as_table(tom.InlineTable(dict))
+  |> should.equal(Ok(dict))
+
   tom.as_table(tom.Int(1))
   |> should.equal(Error(tom.WrongType([], "Table", "Int")))
 }


### PR DESCRIPTION
I assume this should be allowed.
Currently if you try to cast an inline table `as_table` the error says expected `Table` got `Table`.